### PR TITLE
Navigation bar buttons

### DIFF
--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -166,7 +166,16 @@ public class SwiftyGiphyViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
+        
+        if self.navigationController?.presentingViewController != nil
+        {
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
+            self.navigationItem.rightBarButtonItem = nil
+        }
+        else
+        {
+            self.navigationItem.rightBarButtonItem = nil
+        }
     }
 
     public override func viewWillLayoutSubviews() {

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -167,7 +167,7 @@ public class SwiftyGiphyViewController: UIViewController {
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
         
-        if self.navigationController?.viewControllers.count == 1 && self.navigationController?.presentingViewController != nil {
+        if self.navigationController?.viewControllers.count == 1 && self.navigationController?.presentingViewController != nil
         {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
             self.navigationItem.rightBarButtonItem = nil

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -167,7 +167,7 @@ public class SwiftyGiphyViewController: UIViewController {
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
 
-        if self.navigationController?.viewControllers.count == 1 && self.navigationController?.presentingViewController != nil
+        if self.navigationController?.presentingViewController != nil
         {
             self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPicker))
         }

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -166,7 +166,7 @@ public class SwiftyGiphyViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
-        
+
         if self.navigationController?.viewControllers.count == 1 && self.navigationController?.presentingViewController != nil
         {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -166,15 +166,7 @@ public class SwiftyGiphyViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
-
-        if self.navigationController?.presentingViewController != nil
-        {
-            self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
-        }
-        else
-        {
-            self.navigationItem.rightBarButtonItem = nil
-        }
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
     }
 
     public override func viewWillLayoutSubviews() {

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -169,7 +169,7 @@ public class SwiftyGiphyViewController: UIViewController {
 
         if self.navigationController?.presentingViewController != nil
         {
-            self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPicker))
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
         }
         else
         {

--- a/Library/SwiftyGiphyViewController.swift
+++ b/Library/SwiftyGiphyViewController.swift
@@ -167,7 +167,7 @@ public class SwiftyGiphyViewController: UIViewController {
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
         
-        if self.navigationController?.presentingViewController != nil
+        if self.navigationController?.viewControllers.count == 1 && self.navigationController?.presentingViewController != nil {
         {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissPicker))
             self.navigationItem.rightBarButtonItem = nil


### PR DESCRIPTION
This changes the 'Done' button shown in the top right to live in the left corner and read 'Cancel'. 
I think cancel is clearer to the user about what the button does, and the left side in the standard place for this sort of action.